### PR TITLE
Fix millisecond presentation glitch

### DIFF
--- a/src/model/time/position.rs
+++ b/src/model/time/position.rs
@@ -148,7 +148,7 @@ impl Position for Msec {
     // seconds.
 
     fn fmt_value(v: u16, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:0<3}", v)
+        write!(f, "{:0>3}", v)
     }
 
     fn fmt_value_delimited(v: u16, f: &mut fmt::Formatter<'_>) -> fmt::Result {


### PR DESCRIPTION
Previously it was 0-filling to the right, which meant that `7` and `70` were shown as `700`. This fixes it so it 0-fills to the left, so it shows those numbers correctly. Entry still works the same.

Fixes #9 